### PR TITLE
redis: add the option to use a separate redis pool for per second limits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo:     required
 language: go
 go:       "1.10"
 services: redis-server
-env:
-  - REDIS_SOCKET_TYPE=tcp REDIS_URL="localhost:6379"
 install: make bootstrap
+before_script: redis-server --port 6380 &
 script:  make check_format tests

--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@
 - [Request Fields](#request-fields)
 - [Statistics](#statistics)
 - [Debug Port](#debug-port)
+- [Redis](#redis)
+  - [One Redis Instance](#one-redis-instance)
+  - [Two Redis Instances](#two-redis-instances)
 - [Contact](#contact)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -58,10 +61,10 @@ to give time to community members running ratelimit off of `master`.
 * Install redis-server.
 * Make sure go is setup correctly and checkout rate limit service into your go path. More information about installing
 go [here](https://golang.org/doc/install).
-* In order to run the integration tests using a local default redis install you will also need these environment variables set:
+* In order to run the integration tests using a local redis server please run two redis-server instances: one on port `6379` and another on port `6380`
   ```bash
-  export REDIS_SOCKET_TYPE=tcp
-  export REDIS_URL=localhost:6379
+  redis-server --port 6379 &
+  redis-server --port 6380 &
   ```
 * To setup for the first time (only done once):
   ```bash
@@ -351,6 +354,38 @@ $ curl 0:6070/
 ```
 
 You can specify the debug port with the `DEBUG_PORT` environment variable. It defaults to `6070`.
+
+# Redis
+
+Ratelimit uses redis as its caching layer. Ratelimit supports two operation modes:
+
+1. One redis server for all limits.
+1. Two redis instances: one for per second limits and another one for all other limits.
+
+## One Redis Instance
+
+To configure one redis instance use the following environment variables:
+
+1. `REDIS_SOCKET_TYPE`
+1. `REDIS_URL`
+1. `REDIS_POOL_SIZE`
+
+This setup will use the same redis server for all limits.
+
+## Two Redis Instances
+
+To configure two redis instances use the following environment variables:
+
+1. `REDIS_SOCKET_TYPE`
+1. `REDIS_URL`
+1. `REDIS_POOL_SIZE`
+1. `REDIS_PERSECOND`: set this to `"true"`.
+1. `REDIS_PERSECOND_SOCKET_TYPE`
+1. `REDIS_PERSECOND_URL`
+1. `REDIS_PERSECOND_POOL_SIZE`
+
+This setup will use the redis server configured with the `_PERSECOND_` vars for
+per second limits, and the other redis server for all other limits.
 
 # Contact
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 
 The rate limit service is a Go/gRPC service designed to enable generic rate limit scenarios from different types of
 applications. Applications request a rate limit decision based on a domain and a set of descriptors. The service
-reads the configuration from disk via [runtime](https://github.com/lyft/goruntime), composes a cache key, and talks to the redis cache. A
+reads the configuration from disk via [runtime](https://github.com/lyft/goruntime), composes a cache key, and talks to the Redis cache. A
 decision is then returned to the caller.
 
 # Deprecation of Legacy Ratelimit Proto
@@ -58,13 +58,13 @@ to give time to community members running ratelimit off of `master`.
 
 # Building and Testing
 
-* Install redis-server.
+* Install Redis-server.
 * Make sure go is setup correctly and checkout rate limit service into your go path. More information about installing
 go [here](https://golang.org/doc/install).
-* In order to run the integration tests using a local redis server please run two redis-server instances: one on port `6379` and another on port `6380`
+* In order to run the integration tests using a local Redis server please run two Redis-server instances: one on port `6379` and another on port `6380`
   ```bash
-  redis-server --port 6379 &
-  redis-server --port 6380 &
+  Redis-server --port 6379 &
+  Redis-server --port 6380 &
   ```
 * To setup for the first time (only done once):
   ```bash
@@ -357,24 +357,24 @@ You can specify the debug port with the `DEBUG_PORT` environment variable. It de
 
 # Redis
 
-Ratelimit uses redis as its caching layer. Ratelimit supports two operation modes:
+Ratelimit uses Redis as its caching layer. Ratelimit supports two operation modes:
 
-1. One redis server for all limits.
-1. Two redis instances: one for per second limits and another one for all other limits.
+1. One Redis server for all limits.
+1. Two Redis instances: one for per second limits and another one for all other limits.
 
 ## One Redis Instance
 
-To configure one redis instance use the following environment variables:
+To configure one Redis instance use the following environment variables:
 
 1. `REDIS_SOCKET_TYPE`
 1. `REDIS_URL`
 1. `REDIS_POOL_SIZE`
 
-This setup will use the same redis server for all limits.
+This setup will use the same Redis server for all limits.
 
 ## Two Redis Instances
 
-To configure two redis instances use the following environment variables:
+To configure two Redis instances use the following environment variables:
 
 1. `REDIS_SOCKET_TYPE`
 1. `REDIS_URL`
@@ -384,8 +384,8 @@ To configure two redis instances use the following environment variables:
 1. `REDIS_PERSECOND_URL`
 1. `REDIS_PERSECOND_POOL_SIZE`
 
-This setup will use the redis server configured with the `_PERSECOND_` vars for
-per second limits, and the other redis server for all other limits.
+This setup will use the Redis server configured with the `_PERSECOND_` vars for
+per second limits, and the other Redis server for all other limits.
 
 # Contact
 

--- a/src/redis/cache_impl.go
+++ b/src/redis/cache_impl.go
@@ -1,13 +1,13 @@
 package redis
 
 import (
+	"bytes"
 	"math"
 	"math/rand"
 	"strconv"
 	"sync"
 	"time"
 
-	"bytes"
 	pb_struct "github.com/lyft/ratelimit/proto/envoy/api/v2/ratelimit"
 	pb "github.com/lyft/ratelimit/proto/envoy/service/ratelimit/v2"
 	"github.com/lyft/ratelimit/src/assert"

--- a/src/redis/driver_impl.go
+++ b/src/redis/driver_impl.go
@@ -3,7 +3,6 @@ package redis
 import (
 	"github.com/lyft/gostats"
 	"github.com/lyft/ratelimit/src/assert"
-	"github.com/lyft/ratelimit/src/settings"
 	"github.com/mediocregopher/radix.v2/pool"
 	"github.com/mediocregopher/radix.v2/redis"
 	logger "github.com/sirupsen/logrus"
@@ -65,13 +64,13 @@ func (this *poolImpl) Put(c Connection) {
 	}
 }
 
-func NewPoolImpl(scope stats.Scope) Pool {
-	s := settings.NewSettings()
-
-	logger.Warnf("connecting to redis on %s %s with pool size %d", s.RedisSocketType, s.RedisUrl, s.RedisPoolSize)
-	pool, err := pool.New(s.RedisSocketType, s.RedisUrl, s.RedisPoolSize)
+func NewPoolImpl(scope stats.Scope, socketType string, url string, poolSize int) Pool {
+	logger.Warnf("connecting to redis on %s %s with pool size %d", socketType, url, poolSize)
+	pool, err := pool.New(socketType, url, poolSize)
 	checkError(err)
-	return &poolImpl{pool, newPoolStats(scope)}
+	return &poolImpl{
+		pool:  pool,
+		stats: newPoolStats(scope)}
 }
 
 func (this *connectionImpl) PipeAppend(cmd string, args ...interface{}) {

--- a/src/settings/settings.go
+++ b/src/settings/settings.go
@@ -21,6 +21,10 @@ type Settings struct {
 	RedisSocketType            string `envconfig:"REDIS_SOCKET_TYPE" default:"unix"`
 	RedisUrl                   string `envconfig:"REDIS_URL" default:"/var/run/nutcracker/ratelimit.sock"`
 	RedisPoolSize              int    `envconfig:"REDIS_POOL_SIZE" default:"10"`
+	RedisPerSecond             bool   `envconfig:"REDIS_PERSECOND" default:"false"`
+	RedisPerSecondSocketType   string `envconfig:"REDIS_PERSECOND_SOCKET_TYPE" default:"unix"`
+	RedisPerSecondUrl          string `envconfig:"REDIS_PERSECOND_URL" default:"/var/run/nutcracker/ratelimitpersecond.sock"`
+	RedisPerSecondPoolSize     int    `envconfig:"REDIS_PERSECOND_POOL_SIZE" default:"10"`
 	ExpirationJitterMaxSeconds int64  `envconfig:"EXPIRATION_JITTER_MAX_SECONDS" default:"300"`
 }
 

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -3,6 +3,7 @@
 package integration_test
 
 import (
+	"fmt"
 	"math/rand"
 	"os"
 	"strconv"
@@ -12,11 +13,10 @@ import (
 	pb "github.com/lyft/ratelimit/proto/envoy/service/ratelimit/v2"
 	pb_legacy "github.com/lyft/ratelimit/proto/ratelimit"
 	"github.com/lyft/ratelimit/src/service_cmd/runner"
-	"golang.org/x/net/context"
-	"google.golang.org/grpc"
-
 	"github.com/lyft/ratelimit/test/common"
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
 )
 
 func newDescriptorStatus(
@@ -42,98 +42,110 @@ func newDescriptorStatusLegacy(
 }
 
 func TestBasicConfig(t *testing.T) {
-	os.Setenv("PORT", "8082")
-	os.Setenv("GRPC_PORT", "8083")
-	os.Setenv("DEBUG_PORT", "8084")
-	os.Setenv("RUNTIME_ROOT", "runtime/current")
-	os.Setenv("RUNTIME_SUBDIRECTORY", "ratelimit")
+	t.Run("WithoutPerSecondRedis", testBasicConfig("8083", "false"))
+	t.Run("WithPerSecondRedis", testBasicConfig("8085", "true"))
+}
 
-	go func() {
-		runner.Run()
-	}()
+func testBasicConfig(grpcPort, perSecond string) func(*testing.T) {
+	return func(t *testing.T) {
+		os.Setenv("REDIS_PERSECOND", perSecond)
+		os.Setenv("PORT", "8082")
+		os.Setenv("GRPC_PORT", grpcPort)
+		os.Setenv("DEBUG_PORT", "8084")
+		os.Setenv("RUNTIME_ROOT", "runtime/current")
+		os.Setenv("RUNTIME_SUBDIRECTORY", "ratelimit")
+		os.Setenv("REDIS_PERSECOND_SOCKET_TYPE", "tcp")
+		os.Setenv("REDIS_PERSECOND_URL", "localhost:6380")
+		os.Setenv("REDIS_SOCKET_TYPE", "tcp")
+		os.Setenv("REDIS_URL", "localhost:6379")
 
-	// HACK: Wait for the server to come up. Make a hook that we can wait on.
-	time.Sleep(100 * time.Millisecond)
+		go func() {
+			runner.Run()
+		}()
 
-	assert := assert.New(t)
-	conn, err := grpc.Dial("localhost:8083", grpc.WithInsecure())
-	assert.NoError(err)
-	defer conn.Close()
-	c := pb.NewRateLimitServiceClient(conn)
+		// HACK: Wait for the server to come up. Make a hook that we can wait on.
+		time.Sleep(100 * time.Millisecond)
 
-	response, err := c.ShouldRateLimit(
-		context.Background(),
-		common.NewRateLimitRequest("foo", [][][2]string{{{"hello", "world"}}}, 1))
-	assert.Equal(
-		&pb.RateLimitResponse{
-			OverallCode: pb.RateLimitResponse_OK,
-			Statuses:    []*pb.RateLimitResponse_DescriptorStatus{{Code: pb.RateLimitResponse_OK, CurrentLimit: nil, LimitRemaining: 0}}},
-		response)
-	assert.NoError(err)
+		assert := assert.New(t)
+		conn, err := grpc.Dial(fmt.Sprintf("localhost:%s", grpcPort), grpc.WithInsecure())
+		assert.NoError(err)
+		defer conn.Close()
+		c := pb.NewRateLimitServiceClient(conn)
 
-	response, err = c.ShouldRateLimit(
-		context.Background(),
-		common.NewRateLimitRequest("basic", [][][2]string{{{"key1", "foo"}}}, 1))
-	assert.Equal(
-		&pb.RateLimitResponse{
-			OverallCode: pb.RateLimitResponse_OK,
-			Statuses: []*pb.RateLimitResponse_DescriptorStatus{
-				newDescriptorStatus(pb.RateLimitResponse_OK, 50, pb.RateLimitResponse_RateLimit_SECOND, 49)}},
-		response)
-	assert.NoError(err)
-
-	// Now come up with a random key, and go over limit for a minute limit which should always work.
-	r := rand.New(rand.NewSource(time.Now().UnixNano()))
-	randomInt := r.Int()
-	for i := 0; i < 25; i++ {
-		response, err = c.ShouldRateLimit(
+		response, err := c.ShouldRateLimit(
 			context.Background(),
-			common.NewRateLimitRequest(
-				"another", [][][2]string{{{"key2", strconv.Itoa(randomInt)}}}, 1))
-
-		status := pb.RateLimitResponse_OK
-		limitRemaining := uint32(20 - (i + 1))
-		if i >= 20 {
-			status = pb.RateLimitResponse_OVER_LIMIT
-			limitRemaining = 0
-		}
-
+			common.NewRateLimitRequest("foo", [][][2]string{{{"hello", "world"}}}, 1))
 		assert.Equal(
 			&pb.RateLimitResponse{
-				OverallCode: status,
-				Statuses: []*pb.RateLimitResponse_DescriptorStatus{
-					newDescriptorStatus(status, 20, pb.RateLimitResponse_RateLimit_MINUTE, limitRemaining)}},
+				OverallCode: pb.RateLimitResponse_OK,
+				Statuses:    []*pb.RateLimitResponse_DescriptorStatus{{Code: pb.RateLimitResponse_OK, CurrentLimit: nil, LimitRemaining: 0}}},
 			response)
 		assert.NoError(err)
-	}
 
-	// Limit now against 2 keys in the same domain.
-	randomInt = r.Int()
-	for i := 0; i < 15; i++ {
 		response, err = c.ShouldRateLimit(
 			context.Background(),
-			common.NewRateLimitRequest(
-				"another",
-				[][][2]string{
-					{{"key2", strconv.Itoa(randomInt)}},
-					{{"key3", strconv.Itoa(randomInt)}}}, 1))
-
-		status := pb.RateLimitResponse_OK
-		limitRemaining1 := uint32(20 - (i + 1))
-		limitRemaining2 := uint32(10 - (i + 1))
-		if i >= 10 {
-			status = pb.RateLimitResponse_OVER_LIMIT
-			limitRemaining2 = 0
-		}
-
+			common.NewRateLimitRequest("basic", [][][2]string{{{"key1", "foo"}}}, 1))
 		assert.Equal(
 			&pb.RateLimitResponse{
-				OverallCode: status,
+				OverallCode: pb.RateLimitResponse_OK,
 				Statuses: []*pb.RateLimitResponse_DescriptorStatus{
-					newDescriptorStatus(pb.RateLimitResponse_OK, 20, pb.RateLimitResponse_RateLimit_MINUTE, limitRemaining1),
-					newDescriptorStatus(status, 10, pb.RateLimitResponse_RateLimit_HOUR, limitRemaining2)}},
+					newDescriptorStatus(pb.RateLimitResponse_OK, 50, pb.RateLimitResponse_RateLimit_SECOND, 49)}},
 			response)
 		assert.NoError(err)
+
+		// Now come up with a random key, and go over limit for a minute limit which should always work.
+		r := rand.New(rand.NewSource(time.Now().UnixNano()))
+		randomInt := r.Int()
+		for i := 0; i < 25; i++ {
+			response, err = c.ShouldRateLimit(
+				context.Background(),
+				common.NewRateLimitRequest(
+					"another", [][][2]string{{{"key2", strconv.Itoa(randomInt)}}}, 1))
+
+			status := pb.RateLimitResponse_OK
+			limitRemaining := uint32(20 - (i + 1))
+			if i >= 20 {
+				status = pb.RateLimitResponse_OVER_LIMIT
+				limitRemaining = 0
+			}
+
+			assert.Equal(
+				&pb.RateLimitResponse{
+					OverallCode: status,
+					Statuses: []*pb.RateLimitResponse_DescriptorStatus{
+						newDescriptorStatus(status, 20, pb.RateLimitResponse_RateLimit_MINUTE, limitRemaining)}},
+				response)
+			assert.NoError(err)
+		}
+
+		// Limit now against 2 keys in the same domain.
+		randomInt = r.Int()
+		for i := 0; i < 15; i++ {
+			response, err = c.ShouldRateLimit(
+				context.Background(),
+				common.NewRateLimitRequest(
+					"another",
+					[][][2]string{
+						{{"key2", strconv.Itoa(randomInt)}},
+						{{"key3", strconv.Itoa(randomInt)}}}, 1))
+
+			status := pb.RateLimitResponse_OK
+			limitRemaining1 := uint32(20 - (i + 1))
+			limitRemaining2 := uint32(10 - (i + 1))
+			if i >= 10 {
+				status = pb.RateLimitResponse_OVER_LIMIT
+				limitRemaining2 = 0
+			}
+
+			assert.Equal(
+				&pb.RateLimitResponse{
+					OverallCode: status,
+					Statuses: []*pb.RateLimitResponse_DescriptorStatus{
+						newDescriptorStatus(pb.RateLimitResponse_OK, 20, pb.RateLimitResponse_RateLimit_MINUTE, limitRemaining1),
+						newDescriptorStatus(status, 10, pb.RateLimitResponse_RateLimit_HOUR, limitRemaining2)}},
+				response)
+			assert.NoError(err)
+		}
 	}
 }
 

--- a/test/redis/cache_impl_test.go
+++ b/test/redis/cache_impl_test.go
@@ -16,6 +16,141 @@ import (
 )
 
 func TestRedis(t *testing.T) {
+	t.Run("WithoutPerSecondRedis", testRedis(false))
+	t.Run("WithPerSecondRedis", testRedis(true))
+
+}
+
+func testRedis(usePerSecondRedis bool) func(*testing.T) {
+	return func(t *testing.T) {
+		assert := assert.New(t)
+		controller := gomock.NewController(t)
+		defer controller.Finish()
+
+		pool := mock_redis.NewMockPool(controller)
+		perSecondPool := mock_redis.NewMockPool(controller)
+		timeSource := mock_redis.NewMockTimeSource(controller)
+		connection := mock_redis.NewMockConnection(controller)
+		perSecondConnection := mock_redis.NewMockConnection(controller)
+		response := mock_redis.NewMockResponse(controller)
+		var cache redis.RateLimitCache
+		if usePerSecondRedis {
+			cache = redis.NewRateLimitCacheImpl(pool, perSecondPool, timeSource, rand.New(rand.NewSource(1)), 0)
+		} else {
+			cache = redis.NewRateLimitCacheImpl(pool, nil, timeSource, rand.New(rand.NewSource(1)), 0)
+		}
+		statsStore := stats.NewStore(stats.NewNullSink(), false)
+
+		if usePerSecondRedis {
+			perSecondPool.EXPECT().Get().Return(perSecondConnection)
+		}
+		pool.EXPECT().Get().Return(connection)
+		timeSource.EXPECT().UnixNow().Return(int64(1234))
+		var connUsed *mock_redis.MockConnection
+		if usePerSecondRedis {
+			connUsed = perSecondConnection
+		} else {
+			connUsed = connection
+		}
+		connUsed.EXPECT().PipeAppend("INCRBY", "domain_key_value_1234", uint32(1))
+		connUsed.EXPECT().PipeAppend("EXPIRE", "domain_key_value_1234", int64(1))
+		connUsed.EXPECT().PipeResponse().Return(response)
+		response.EXPECT().Int().Return(int64(5))
+		connUsed.EXPECT().PipeResponse()
+		if usePerSecondRedis {
+			perSecondPool.EXPECT().Put(perSecondConnection)
+		}
+		pool.EXPECT().Put(connection)
+
+		request := common.NewRateLimitRequest("domain", [][][2]string{{{"key", "value"}}}, 1)
+		limits := []*config.RateLimit{config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_SECOND, "key_value", statsStore)}
+
+		assert.Equal(
+			[]*pb.RateLimitResponse_DescriptorStatus{{Code: pb.RateLimitResponse_OK, CurrentLimit: limits[0].Limit, LimitRemaining: 5}},
+			cache.DoLimit(nil, request, limits))
+		assert.Equal(uint64(1), limits[0].Stats.TotalHits.Value())
+		assert.Equal(uint64(0), limits[0].Stats.OverLimit.Value())
+		assert.Equal(uint64(0), limits[0].Stats.NearLimit.Value())
+
+		if usePerSecondRedis {
+			perSecondPool.EXPECT().Get().Return(perSecondConnection)
+		}
+		pool.EXPECT().Get().Return(connection)
+		timeSource.EXPECT().UnixNow().Return(int64(1234))
+		connection.EXPECT().PipeAppend("INCRBY", "domain_key2_value2_subkey2_subvalue2_1200", uint32(1))
+		connection.EXPECT().PipeAppend(
+			"EXPIRE", "domain_key2_value2_subkey2_subvalue2_1200", int64(60))
+		connection.EXPECT().PipeResponse().Return(response)
+		response.EXPECT().Int().Return(int64(11))
+		connection.EXPECT().PipeResponse()
+		if usePerSecondRedis {
+			perSecondPool.EXPECT().Put(perSecondConnection)
+		}
+		pool.EXPECT().Put(connection)
+
+		request = common.NewRateLimitRequest(
+			"domain",
+			[][][2]string{
+				{{"key2", "value2"}},
+				{{"key2", "value2"}, {"subkey2", "subvalue2"}},
+			}, 1)
+		limits = []*config.RateLimit{
+			nil,
+			config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, "key2_value2_subkey2_subvalue2", statsStore)}
+		assert.Equal(
+			[]*pb.RateLimitResponse_DescriptorStatus{{Code: pb.RateLimitResponse_OK, CurrentLimit: nil, LimitRemaining: 0},
+				{Code: pb.RateLimitResponse_OVER_LIMIT, CurrentLimit: limits[1].Limit, LimitRemaining: 0}},
+			cache.DoLimit(nil, request, limits))
+		assert.Equal(uint64(1), limits[1].Stats.TotalHits.Value())
+		assert.Equal(uint64(1), limits[1].Stats.OverLimit.Value())
+		assert.Equal(uint64(0), limits[1].Stats.NearLimit.Value())
+
+		if usePerSecondRedis {
+			perSecondPool.EXPECT().Get().Return(perSecondConnection)
+		}
+		pool.EXPECT().Get().Return(connection)
+		timeSource.EXPECT().UnixNow().Return(int64(1000000))
+		connection.EXPECT().PipeAppend("INCRBY", "domain_key3_value3_997200", uint32(1))
+		connection.EXPECT().PipeAppend(
+			"EXPIRE", "domain_key3_value3_997200", int64(3600))
+		connection.EXPECT().PipeAppend("INCRBY", "domain_key3_value3_subkey3_subvalue3_950400", uint32(1))
+		connection.EXPECT().PipeAppend(
+			"EXPIRE", "domain_key3_value3_subkey3_subvalue3_950400", int64(86400))
+		connection.EXPECT().PipeResponse().Return(response)
+		response.EXPECT().Int().Return(int64(11))
+		connection.EXPECT().PipeResponse()
+		connection.EXPECT().PipeResponse().Return(response)
+		response.EXPECT().Int().Return(int64(13))
+		connection.EXPECT().PipeResponse()
+		if usePerSecondRedis {
+			perSecondPool.EXPECT().Put(perSecondConnection)
+		}
+		pool.EXPECT().Put(connection)
+
+		request = common.NewRateLimitRequest(
+			"domain",
+			[][][2]string{
+				{{"key3", "value3"}},
+				{{"key3", "value3"}, {"subkey3", "subvalue3"}},
+			}, 1)
+		limits = []*config.RateLimit{
+			config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_HOUR, "key3_value3", statsStore),
+			config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_DAY, "key3_value3_subkey3_subvalue3", statsStore)}
+		assert.Equal(
+			[]*pb.RateLimitResponse_DescriptorStatus{
+				{Code: pb.RateLimitResponse_OVER_LIMIT, CurrentLimit: limits[0].Limit, LimitRemaining: 0},
+				{Code: pb.RateLimitResponse_OVER_LIMIT, CurrentLimit: limits[1].Limit, LimitRemaining: 0}},
+			cache.DoLimit(nil, request, limits))
+		assert.Equal(uint64(1), limits[0].Stats.TotalHits.Value())
+		assert.Equal(uint64(1), limits[0].Stats.OverLimit.Value())
+		assert.Equal(uint64(0), limits[0].Stats.NearLimit.Value())
+		assert.Equal(uint64(1), limits[0].Stats.TotalHits.Value())
+		assert.Equal(uint64(1), limits[0].Stats.OverLimit.Value())
+		assert.Equal(uint64(0), limits[0].Stats.NearLimit.Value())
+	}
+}
+
+func TestNearLimit(t *testing.T) {
 	assert := assert.New(t)
 	controller := gomock.NewController(t)
 	defer controller.Finish()
@@ -24,91 +159,8 @@ func TestRedis(t *testing.T) {
 	timeSource := mock_redis.NewMockTimeSource(controller)
 	connection := mock_redis.NewMockConnection(controller)
 	response := mock_redis.NewMockResponse(controller)
-	cache := redis.NewRateLimitCacheImpl(pool, timeSource, rand.New(rand.NewSource(1)), 0)
+	cache := redis.NewRateLimitCacheImpl(pool, nil, timeSource, rand.New(rand.NewSource(1)), 0)
 	statsStore := stats.NewStore(stats.NewNullSink(), false)
-
-	pool.EXPECT().Get().Return(connection)
-	timeSource.EXPECT().UnixNow().Return(int64(1234))
-	connection.EXPECT().PipeAppend("INCRBY", "domain_key_value_1234", uint32(1))
-	connection.EXPECT().PipeAppend("EXPIRE", "domain_key_value_1234", int64(1))
-	connection.EXPECT().PipeResponse().Return(response)
-	response.EXPECT().Int().Return(int64(5))
-	connection.EXPECT().PipeResponse()
-	pool.EXPECT().Put(connection)
-
-	request := common.NewRateLimitRequest("domain", [][][2]string{{{"key", "value"}}}, 1)
-	limits := []*config.RateLimit{config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_SECOND, "key_value", statsStore)}
-
-	assert.Equal(
-		[]*pb.RateLimitResponse_DescriptorStatus{{Code: pb.RateLimitResponse_OK, CurrentLimit: limits[0].Limit, LimitRemaining: 5}},
-		cache.DoLimit(nil, request, limits))
-	assert.Equal(uint64(1), limits[0].Stats.TotalHits.Value())
-	assert.Equal(uint64(0), limits[0].Stats.OverLimit.Value())
-	assert.Equal(uint64(0), limits[0].Stats.NearLimit.Value())
-
-	pool.EXPECT().Get().Return(connection)
-	timeSource.EXPECT().UnixNow().Return(int64(1234))
-	connection.EXPECT().PipeAppend("INCRBY", "domain_key2_value2_subkey2_subvalue2_1200", uint32(1))
-	connection.EXPECT().PipeAppend(
-		"EXPIRE", "domain_key2_value2_subkey2_subvalue2_1200", int64(60))
-	connection.EXPECT().PipeResponse().Return(response)
-	response.EXPECT().Int().Return(int64(11))
-	connection.EXPECT().PipeResponse()
-	pool.EXPECT().Put(connection)
-
-	request = common.NewRateLimitRequest(
-		"domain",
-		[][][2]string{
-			{{"key2", "value2"}},
-			{{"key2", "value2"}, {"subkey2", "subvalue2"}},
-		}, 1)
-	limits = []*config.RateLimit{
-		nil,
-		config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, "key2_value2_subkey2_subvalue2", statsStore)}
-	assert.Equal(
-		[]*pb.RateLimitResponse_DescriptorStatus{{Code: pb.RateLimitResponse_OK, CurrentLimit: nil, LimitRemaining: 0},
-			{Code: pb.RateLimitResponse_OVER_LIMIT, CurrentLimit: limits[1].Limit, LimitRemaining: 0}},
-		cache.DoLimit(nil, request, limits))
-	assert.Equal(uint64(1), limits[1].Stats.TotalHits.Value())
-	assert.Equal(uint64(1), limits[1].Stats.OverLimit.Value())
-	assert.Equal(uint64(0), limits[1].Stats.NearLimit.Value())
-
-	pool.EXPECT().Get().Return(connection)
-	timeSource.EXPECT().UnixNow().Return(int64(1000000))
-	connection.EXPECT().PipeAppend("INCRBY", "domain_key3_value3_997200", uint32(1))
-	connection.EXPECT().PipeAppend(
-		"EXPIRE", "domain_key3_value3_997200", int64(3600))
-	connection.EXPECT().PipeAppend("INCRBY", "domain_key3_value3_subkey3_subvalue3_950400", uint32(1))
-	connection.EXPECT().PipeAppend(
-		"EXPIRE", "domain_key3_value3_subkey3_subvalue3_950400", int64(86400))
-	connection.EXPECT().PipeResponse().Return(response)
-	response.EXPECT().Int().Return(int64(11))
-	connection.EXPECT().PipeResponse()
-	connection.EXPECT().PipeResponse().Return(response)
-	response.EXPECT().Int().Return(int64(13))
-	connection.EXPECT().PipeResponse()
-	pool.EXPECT().Put(connection)
-
-	request = common.NewRateLimitRequest(
-		"domain",
-		[][][2]string{
-			{{"key3", "value3"}},
-			{{"key3", "value3"}, {"subkey3", "subvalue3"}},
-		}, 1)
-	limits = []*config.RateLimit{
-		config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_HOUR, "key3_value3", statsStore),
-		config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_DAY, "key3_value3_subkey3_subvalue3", statsStore)}
-	assert.Equal(
-		[]*pb.RateLimitResponse_DescriptorStatus{
-			{Code: pb.RateLimitResponse_OVER_LIMIT, CurrentLimit: limits[0].Limit, LimitRemaining: 0},
-			{Code: pb.RateLimitResponse_OVER_LIMIT, CurrentLimit: limits[1].Limit, LimitRemaining: 0}},
-		cache.DoLimit(nil, request, limits))
-	assert.Equal(uint64(1), limits[0].Stats.TotalHits.Value())
-	assert.Equal(uint64(1), limits[0].Stats.OverLimit.Value())
-	assert.Equal(uint64(0), limits[0].Stats.NearLimit.Value())
-	assert.Equal(uint64(1), limits[0].Stats.TotalHits.Value())
-	assert.Equal(uint64(1), limits[0].Stats.OverLimit.Value())
-	assert.Equal(uint64(0), limits[0].Stats.NearLimit.Value())
 
 	// Test Near Limit Stats. Under Near Limit Ratio
 	pool.EXPECT().Get().Return(connection)
@@ -121,9 +173,9 @@ func TestRedis(t *testing.T) {
 	connection.EXPECT().PipeResponse()
 	pool.EXPECT().Put(connection)
 
-	request = common.NewRateLimitRequest("domain", [][][2]string{{{"key4", "value4"}}}, 1)
+	request := common.NewRateLimitRequest("domain", [][][2]string{{{"key4", "value4"}}}, 1)
 
-	limits = []*config.RateLimit{
+	limits := []*config.RateLimit{
 		config.NewRateLimit(15, pb.RateLimitResponse_RateLimit_HOUR, "key4_value4", statsStore)}
 
 	assert.Equal(
@@ -305,7 +357,7 @@ func TestRedisWithJitter(t *testing.T) {
 	connection := mock_redis.NewMockConnection(controller)
 	response := mock_redis.NewMockResponse(controller)
 	jitterSource := mock_redis.NewMockJitterRandSource(controller)
-	cache := redis.NewRateLimitCacheImpl(pool, timeSource, rand.New(jitterSource), 3600)
+	cache := redis.NewRateLimitCacheImpl(pool, nil, timeSource, rand.New(jitterSource), 3600)
 	statsStore := stats.NewStore(stats.NewNullSink(), false)
 
 	pool.EXPECT().Get().Return(connection)


### PR DESCRIPTION
@lyft/network-team Add the option to use a separate redis pool for per second limits. This allows operators to scale the two clusters independently.