### PR TITLE
fix duplicate mv in scripts/install-protoc

### DIFF
--- a/script/install-protoc
+++ b/script/install-protoc
@@ -9,7 +9,7 @@ unzip "${PROTOC_REL}" -d protoc
 if which sudo >/dev/null;
     then sudo mv protoc /usr/local && sudo ln -s /usr/local/protoc/bin/protoc /usr/local/bin
 else
-    mv mv protoc /usr/local && ln -s /usr/local/protoc/bin/protoc /usr/local/bin
+    mv protoc /usr/local && ln -s /usr/local/protoc/bin/protoc /usr/local/bin
 fi
 popd
 go get -u github.com/golang/protobuf/protoc-gen-go


### PR DESCRIPTION
While creating a docker build for ratelimit that would run on my Macbook, I noticed that there is an error in the scripts/install-protoc script when running on a system without sudo (which the golang default docker image is). 

This patch should fix that.

The sed script I used to do this has also corrected a missing newline at the end of the file.

@lyft/network-team