### PR TITLE
docker: upgrade docker-compose setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,0 @@
-FROM alpine:3.6
-ADD bin/ratelimit* /bin/
-CMD ["/bin/ratelimit"]

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 - [Deprecation of Legacy Ratelimit Proto](#deprecation-of-legacy-ratelimit-proto)
   - [Deprecation Schedule](#deprecation-schedule)
 - [Building and Testing](#building-and-testing)
+  - [Docker-compose setup](#docker-compose-setup)
 - [Configuration](#configuration)
   - [The configuration format](#the-configuration-format)
     - [Definitions](#definitions)
@@ -89,6 +90,22 @@ go [here](https://golang.org/doc/install).
   ```bash
   USE_STATSD=false LOG_LEVEL=debug REDIS_SOCKET_TYPE=tcp REDIS_URL=localhost:6379 RUNTIME_ROOT=/home/user/src/runtime/data RUNTIME_SUBDIRECTORY=ratelimit
   ```
+
+## Docker-compose setup
+
+The docker-compose setup has three containers: redis, ratelimit-build, and ratelimit. In order to run the docker-compose setup from the root of the repo, run
+
+```bash
+glide install
+docker-compose up
+```
+
+The ratelimit-build container will build the ratelimit binary. Then via a shared volume the binary will be shared with the ratelimit container. This dual container setup is used in order to use a
+a minimal container to run the application, rather than the heftier container used to build it.
+
+If you want to run with [two redis instances](#two-redis-instances), you will need to modify
+the docker-compose.yaml file to run a second redis container, and change the environment variables
+as explained in the [two redis instances](#two-redis-instances) section.
 
 # Configuration
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,27 +6,33 @@ services:
     expose:
       - 6379
     ports:
-      - "6379:6379"
+      - 6379:6379
     networks:
-      - data
+      - ratelimit-network
+
+  # minimal container that builds the ratelimit service binary and exits.
+  ratelimit-build:
+    image: golang:1.10-alpine
+    working_dir: /go/src/github.com/lyft/ratelimit
+    command: go build -o /usr/local/bin/ratelimit /go/src/github.com/lyft/ratelimit/src/service_cmd/main.go
     volumes:
-      - redis-data:/data
+      - .:/go/src/github.com/lyft/ratelimit
+      - binary:/usr/local/bin/
 
   ratelimit:
-    build:
-      context: ./
-      dockerfile: Dockerfile
+    image: alpine:3.6
+    command: /usr/local/bin/ratelimit
     ports:
       - 8080:8080
       - 6070:6070
     depends_on:
       - redis
+      - ratelimit-build
     networks:
-      - data
-    links:
-      - redis
+      - ratelimit-network
     volumes:
-      - ./examples:/data/
+      - binary:/usr/local/bin/
+      - ./examples:/data
     environment:
       - USE_STATSD=false
       - LOG_LEVEL=debug
@@ -36,8 +42,7 @@ services:
       - RUNTIME_SUBDIRECTORY=ratelimit
 
 networks:
-  data:
+  ratelimit-network:
 
 volumes:
-  redis-data:
-  ratelimit-data:
+  binary:


### PR DESCRIPTION
@lyft/network-team previously the ratelimit docker container used the binary built on the host. This leads to incompatibility if the host OS and the container OS don't match. 

This PR adds an additional container `ratelimit-build` which builds the ratelimit binary and shares it via a shared volume to the `ratelimit` container. I also went ahead and cleaned up the whole docker setup a bit, and added readme docs for it.