### PR TITLE
Add gRPC health check

### DIFF
--- a/test/server/health_test.go
+++ b/test/server/health_test.go
@@ -1,6 +1,7 @@
 package server_test
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"os/signal"
@@ -8,6 +9,9 @@ import (
 	"testing"
 
 	"github.com/lyft/ratelimit/src/server"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/health"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 )
 
 func TestHealthCheck(t *testing.T) {
@@ -15,7 +19,7 @@ func TestHealthCheck(t *testing.T) {
 
 	recorder := httptest.NewRecorder()
 
-	hc := server.NewHealthChecker()
+	hc := server.NewHealthChecker(health.NewServer())
 
 	r, _ := http.NewRequest("GET", "http://1.2.3.4/healthcheck", nil)
 	hc.ServeHTTP(recorder, r)
@@ -39,4 +43,28 @@ func TestHealthCheck(t *testing.T) {
 		t.Errorf("expected code 500 actual %d", recorder.Code)
 	}
 
+}
+
+func TestGrpcHealthCheck(t *testing.T) {
+	defer signal.Reset(syscall.SIGTERM)
+
+	grpcHealthServer := health.NewServer()
+	hc := server.NewHealthChecker(grpcHealthServer)
+	healthpb.RegisterHealthServer(grpc.NewServer(), grpcHealthServer)
+
+	req := &healthpb.HealthCheckRequest{
+		Service: "ratelimit",
+	}
+
+	res, _ := grpcHealthServer.Check(context.Background(), req)
+	if healthpb.HealthCheckResponse_SERVING != res.Status {
+		t.Errorf("expected status SERVING actual %v", res.Status)
+	}
+
+	hc.Fail()
+
+	res, _ = grpcHealthServer.Check(context.Background(), req)
+	if healthpb.HealthCheckResponse_NOT_SERVING != res.Status {
+		t.Errorf("expected status NOT_SERVING actual %v", res.Status)
+	}
 }


### PR DESCRIPTION
Envoy supports [gRPC health checks](https://www.envoyproxy.io/docs/envoy/v1.7.1/api-v2/api/v2/core/health_check.proto#envoy-api-msg-core-healthcheck-grpchealthcheck) based on [grpc.health.v1.Health](https://github.com/grpc/grpc/blob/master/doc/health-checking.md).

This change implements that health check protocol.

Envoy configuration example:
```yaml
        health_checks:
          - timeout: 0.2s
            interval: 1s
            unhealthy_threshold: 2
            healthy_threshold: 2
            grpc_health_check:
              service_name: "ratelimit"
```