### PR TITLE
logging: set log level

### DIFF
--- a/src/service_cmd/runner/runner.go
+++ b/src/service_cmd/runner/runner.go
@@ -14,12 +14,20 @@ import (
 	"github.com/lyft/ratelimit/src/server"
 	"github.com/lyft/ratelimit/src/service"
 	"github.com/lyft/ratelimit/src/settings"
+	logger "github.com/sirupsen/logrus"
 )
 
 func Run() {
-	srv := server.NewServer("ratelimit", settings.GrpcUnaryInterceptor(nil))
-
 	s := settings.NewSettings()
+
+	logLevel, err := logger.ParseLevel(s.LogLevel)
+	if err != nil {
+		logger.Fatalf("Could not parse log level. %v\n", err)
+	} else {
+		logger.SetLevel(logLevel)
+	}
+
+	srv := server.NewServer("ratelimit", settings.GrpcUnaryInterceptor(nil))
 
 	var perSecondPool redis.Pool
 	if s.RedisPerSecond {


### PR DESCRIPTION
@lyft/network-team ratelimit was not using the env config to appropriately set the log level. This PR fixes that issue.