### PR TITLE
Configuration to ignore dotfiles.

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,8 +311,9 @@ The path to watch can be configured via the [settings](https://github.com/lyft/r
 package with the following environment variables:
 
 ```
-RUNTIME_ROOT default:"/srv/runtime_data/current"`
+RUNTIME_ROOT default:"/srv/runtime_data/current"
 RUNTIME_SUBDIRECTORY
+RUNTIME_IGNOREDOTFILES default:"false"
 ```
 
 **Configuration files are loaded from RUNTIME_ROOT/RUNTIME_SUBDIRECTORY/config/\*.yaml**

--- a/glide.yaml
+++ b/glide.yaml
@@ -9,7 +9,7 @@ import:
 - package: github.com/lyft/gostats
   version: v0.2.6
 - package: github.com/lyft/goruntime
-  version: v0.1.8
+  version: v0.1.9
 - package: github.com/mediocregopher/radix.v2
   version: master
   subpackages:

--- a/src/server/server_impl.go
+++ b/src/server/server_impl.go
@@ -124,7 +124,12 @@ func newServer(name string, opts ...settings.Option) *server {
 	ret.store.AddStatGenerator(stats.NewRuntimeStats(ret.scope.Scope("go")))
 
 	// setup runtime
-	ret.runtime = loader.New(s.RuntimePath, s.RuntimeSubdirectory, ret.store.Scope("runtime"), &loader.SymlinkRefresher{s.RuntimePath})
+	ret.runtime = loader.New(
+		s.RuntimePath,
+		s.RuntimeSubdirectory,
+		ret.store.Scope("runtime"),
+		&loader.SymlinkRefresher{s.RuntimePath},
+		s.RuntimeIgnoreDotFiles)
 
 	// setup http router
 	ret.router = mux.NewRouter()

--- a/src/settings/settings.go
+++ b/src/settings/settings.go
@@ -17,6 +17,7 @@ type Settings struct {
 	StatsdPort                 int    `envconfig:"STATSD_PORT" default:"8125"`
 	RuntimePath                string `envconfig:"RUNTIME_ROOT" default:"/srv/runtime_data/current"`
 	RuntimeSubdirectory        string `envconfig:"RUNTIME_SUBDIRECTORY"`
+	RuntimeIgnoreDotFiles      bool   `envconfig:"RUNTIME_IGNOREDOTFILES" default:"false"`
 	LogLevel                   string `envconfig:"LOG_LEVEL" default:"WARN"`
 	RedisSocketType            string `envconfig:"REDIS_SOCKET_TYPE" default:"unix"`
 	RedisUrl                   string `envconfig:"REDIS_URL" default:"/var/run/nutcracker/ratelimit.sock"`


### PR DESCRIPTION
This allows ratelimit to run on Kubernetes with configuration from a configmap.

TODO:
lyft/goruntime needs tagging at v0.1.9 (or perhaps later since it was a breaking change), and glide up needs to be run.