### PR TITLE
Configuration to ignore dotfiles.

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,8 +311,9 @@ The path to watch can be configured via the [settings](https://github.com/lyft/r
 package with the following environment variables:
 
 ```
-RUNTIME_ROOT default:"/srv/runtime_data/current"`
+RUNTIME_ROOT default:"/srv/runtime_data/current"
 RUNTIME_SUBDIRECTORY
+RUNTIME_IGNOREDOTFILES default:"false"
 ```
 
 **Configuration files are loaded from RUNTIME_ROOT/RUNTIME_SUBDIRECTORY/config/\*.yaml**

--- a/glide.lock
+++ b/glide.lock
@@ -1,35 +1,35 @@
-hash: fe989994477e78bb58fd50892030bc6c0d0bbbf95b50012e7e9b10e2b2bd0f8d
-updated: 2018-06-07T16:52:24.670498-07:00
+hash: 8eb465e3dce54065826786f6eb25807589fe99dd548db5988ed8db0cbaede809
+updated: 2018-10-03T00:32:46.325855583+01:00
 imports:
 - name: github.com/envoyproxy/data-plane-api
   version: 0f8a2a3d456de4d3a29f4e8f7a641fef011d1394
 - name: github.com/fsnotify/fsnotify
   version: 629574ca2a5df945712d3079857300b5e4da0236
 - name: github.com/golang/mock
-  version: 22bbf0ddf08105dfa364d0a2fa619dfa71014af5
+  version: 600781dde9cca80734169b9e969d9054ccc57937
   subpackages:
   - gomock
 - name: github.com/golang/protobuf
   version: b4deda0973fb4c70b50d226b1af49f3da59f5265
   subpackages:
+  - jsonpb
   - proto
   - protoc-gen-go/descriptor
   - ptypes
   - ptypes/any
   - ptypes/duration
+  - ptypes/struct
   - ptypes/timestamp
 - name: github.com/google/protobuf
   version: 106ffc04be1abf3ff3399f54ccf149815b287dd9
-- name: github.com/gorilla/context
-  version: 08b5f424b9271eedf6f9f0ce86cb9396ed337a42
 - name: github.com/gorilla/mux
-  version: 53c1911da2b537f792e7cafcb446b05ffe33b996
+  version: 9e1f5955c0d22b55d9e20d6faa28589f83b2faca
 - name: github.com/kavu/go_reuseport
   version: 3d6c1e425f717ee59152524e73b904b67705eeb8
 - name: github.com/kelseyhightower/envconfig
   version: ac12b1f15efba734211a556d8b125110dc538016
 - name: github.com/lyft/goruntime
-  version: 426ae3581aca6d8b997300525e0d075444bd68d1
+  version: a0d6acf20fcfd48f53e623ed62b87ffb7fe17038
   subpackages:
   - loader
   - snapshot
@@ -46,17 +46,17 @@ imports:
   - pool
   - redis
 - name: github.com/sirupsen/logrus
-  version: c155da19408a8799da419ed3eeb0cb5db0ad5dbc
+  version: 3e01752db0189b9157070a0e1668a620f9a85da2
 - name: github.com/stretchr/testify
   version: f390dcf405f7b83c997eac1b06768bb9f44dec18
   subpackages:
   - assert
 - name: golang.org/x/crypto
-  version: 91a49db82a88618983a78a06c1cbd4e00ab749ab
+  version: e3636079e1a4c1f337f212cc5cd2aca108f6c900
   subpackages:
   - ssh/terminal
 - name: golang.org/x/net
-  version: 1e491301e022f8f977054da4c2d852decd59571f
+  version: 4dfa2610cdf3b287375bbba5b8f2a14d3b01d8de
   subpackages:
   - context
   - http/httpguts
@@ -66,19 +66,19 @@ imports:
   - internal/timeseries
   - trace
 - name: golang.org/x/sys
-  version: f6cff0780e542efa0c8e864dc8fa522808f6a598
+  version: e4b3c5e9061176387e7cea65e4dc5853801f3fb7
   subpackages:
   - unix
   - windows
 - name: golang.org/x/text
-  version: 27420a1a391f5504f73155051cd274311bf70883
+  version: 905a57155faa8230500121607930ebb9dd8e139c
   subpackages:
   - secure/bidirule
   - transform
   - unicode/bidi
   - unicode/norm
 - name: google.golang.org/genproto
-  version: 2d9486acae19cf9bd0c093d7dc236a323726a9e4
+  version: c7e5094acea1ca1b899e2259d80a6b0f882f81f8
   subpackages:
   - googleapis/rpc/status
 - name: google.golang.org/grpc
@@ -95,6 +95,8 @@ imports:
   - encoding/proto
   - grpclb/grpc_lb_v1/messages
   - grpclog
+  - health
+  - health/grpc_health_v1
   - internal
   - keepalive
   - metadata

--- a/glide.yaml
+++ b/glide.yaml
@@ -9,7 +9,7 @@ import:
 - package: github.com/lyft/gostats
   version: v0.2.6
 - package: github.com/lyft/goruntime
-  version: v0.1.8
+  version: v0.2.1
 - package: github.com/mediocregopher/radix.v2
   version: master
   subpackages:

--- a/src/server/server_impl.go
+++ b/src/server/server_impl.go
@@ -124,7 +124,19 @@ func newServer(name string, opts ...settings.Option) *server {
 	ret.store.AddStatGenerator(stats.NewRuntimeStats(ret.scope.Scope("go")))
 
 	// setup runtime
-	ret.runtime = loader.New(s.RuntimePath, s.RuntimeSubdirectory, ret.store.Scope("runtime"), &loader.SymlinkRefresher{s.RuntimePath})
+	loaderOpts := make([]loader.Option, 0, 1)
+	if s.RuntimeIgnoreDotFiles {
+		loaderOpts = append(loaderOpts, loader.IgnoreDotFiles)
+	} else {
+		loaderOpts = append(loaderOpts, loader.AllowDotFiles)
+	}
+
+	ret.runtime = loader.New(
+		s.RuntimePath,
+		s.RuntimeSubdirectory,
+		ret.store.Scope("runtime"),
+		&loader.SymlinkRefresher{RuntimePath: s.RuntimePath},
+		loaderOpts...)
 
 	// setup http router
 	ret.router = mux.NewRouter()

--- a/src/settings/settings.go
+++ b/src/settings/settings.go
@@ -17,6 +17,7 @@ type Settings struct {
 	StatsdPort                 int    `envconfig:"STATSD_PORT" default:"8125"`
 	RuntimePath                string `envconfig:"RUNTIME_ROOT" default:"/srv/runtime_data/current"`
 	RuntimeSubdirectory        string `envconfig:"RUNTIME_SUBDIRECTORY"`
+	RuntimeIgnoreDotFiles      bool   `envconfig:"RUNTIME_IGNOREDOTFILES" default:"false"`
 	LogLevel                   string `envconfig:"LOG_LEVEL" default:"WARN"`
 	RedisSocketType            string `envconfig:"REDIS_SOCKET_TYPE" default:"unix"`
 	RedisUrl                   string `envconfig:"REDIS_URL" default:"/var/run/nutcracker/ratelimit.sock"`


### PR DESCRIPTION
This allows ratelimit to run on Kubernetes with configuration from a configmap.