### PR TITLE
docker compose: expose gRPC port on docker compose setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,7 @@ services:
     command: /usr/local/bin/ratelimit
     ports:
       - 8080:8080
+      - 8081:8081
       - 6070:6070
     depends_on:
       - redis


### PR DESCRIPTION
@lyft/network-team fixing an oversight. The gRPC port is not being exposed.

cc @tonya11en