### PR TITLE
Add Dockerfile to enable builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM golang:1.10.4 AS build
+WORKDIR /go/src/github.com/lyft/ratelimit
+
+COPY src src
+COPY script script
+COPY vendor vendor
+COPY proto proto
+COPY glide.yaml glide.yaml
+COPY glide.lock glide.lock
+
+RUN go get -u github.com/golang/protobuf/protoc-gen-go
+RUN script/install-glide
+RUN glide install
+
+RUN CGO_ENABLED=0 GOOS=linux go build -o /usr/local/bin/ratelimit -ldflags="-w -s" -v github.com/lyft/ratelimit/src/service_cmd
+
+FROM alpine:3.8 AS final
+RUN apk --no-cache add ca-certificates
+COPY --from=build /usr/local/bin/ratelimit /bin/ratelimit


### PR DESCRIPTION
This adds a simple Dockerfile which produces a docker image that can be pushed to a container registry. 

Updates #57 

Signed-off-by: Steve Sloka <steves@heptio.com>