### PR TITLE
Run unit and integration tests with race detector enabled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,11 +37,11 @@ compile: proto
 
 .PHONY: tests_unit
 tests_unit: compile
-	go test $(shell glide nv)
+	go test -race ./...
 
 .PHONY: tests
 tests: compile
-	go test $(shell glide nv) -tags=integration
+	go test -race -tags=integration ./...
 
 .PHONY: proto
 proto:

--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ descriptors:
   - key: key
     value: value
     descriptors:
-      - key: subkey      
+      - key: subkey
         rate_limit:
           -  requests_per_unit: 300
              unit: second


### PR DESCRIPTION
Run unit and integration tests with the [race detector](https://golang.org/doc/articles/race_detector.html) enabled.