### PR TITLE
Copy the "proto" directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /go/src/github.com/lyft/ratelimit
 COPY src src
 COPY script script
 COPY vendor vendor
+COPY proto proto
 COPY glide.yaml glide.yaml
 COPY glide.lock glide.lock
 


### PR DESCRIPTION
When I built the image using Dockerfile, I encountered the following error：

```plaintext
Removing intermediate container 92ad6fedd717
 ---> 2e69ec57bf34
Step 10/13 : RUN CGO_ENABLED=0 GOOS=linux go build -o /usr/local/bin/ratelimit -ldflags="-w -s" -v github.com/lyft/ratelimit/src/service_cmd
 ---> Running in eb189e392932
src/service_cmd/runner/runner.go:10:2: cannot find package "github.com/lyft/ratelimit/proto/ratelimit" in any of:
	/go/src/github.com/lyft/ratelimit/vendor/github.com/lyft/ratelimit/proto/ratelimit (vendor tree)
	/usr/local/go/src/github.com/lyft/ratelimit/proto/ratelimit (from $GOROOT)
	/go/src/github.com/lyft/ratelimit/proto/ratelimit (from $GOPATH)
The command '/bin/sh -c CGO_ENABLED=0 GOOS=linux go build -o /usr/local/bin/ratelimit -ldflags="-w -s" -v github.com/lyft/ratelimit/src/service_cmd' returned a non-zero code: 1
```
After adding the following line to the Dockerfile, It’s successful:

```bash
COPY proto proto
```