### PR TITLE
Fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /go/src/github.com/lyft/ratelimit
 
 COPY src src
 COPY script script
-COPY vendor vendor
+COPY proto proto
 COPY glide.yaml glide.yaml
 COPY glide.lock glide.lock
 


### PR DESCRIPTION
The vendor folder gets generated in the Docker image.
COPY vendor vendor fails since the folder does not exist in the host directory.

protos need to be copied over for the build to succeed.