### PR TITLE
fix docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /go/src/github.com/lyft/ratelimit
 
 COPY src src
 COPY script script
-COPY vendor vendor
+COPY proto proto
 COPY glide.yaml glide.yaml
 COPY glide.lock glide.lock
 


### PR DESCRIPTION
Removed `COPY vendor` because the repo doesn't have it, and added `COPY proto` because we need the proto definitions for the project to build. This change can be tested by running `docker build`