### PR TITLE
use dockerfile to build the image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ cover.out
 bin/
 .idea/
 vendor
+.glide

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /go/src/github.com/lyft/ratelimit
 COPY src src
 COPY script script
 COPY vendor vendor
+COPY proto proto
 COPY glide.yaml glide.yaml
 COPY glide.lock glide.lock
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10.4 AS build
+FROM golang:1.11 AS build
 WORKDIR /go/src/github.com/lyft/ratelimit
 
 COPY src src

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,29 +10,18 @@ services:
     networks:
       - ratelimit-network
 
-  # minimal container that builds the ratelimit service binary and exits.
-  ratelimit-build:
-    image: golang:1.10-alpine
-    working_dir: /go/src/github.com/lyft/ratelimit
-    command: go build -o /usr/local/bin/ratelimit /go/src/github.com/lyft/ratelimit/src/service_cmd/main.go
-    volumes:
-      - .:/go/src/github.com/lyft/ratelimit
-      - binary:/usr/local/bin/
-
   ratelimit:
-    image: alpine:3.6
-    command: /usr/local/bin/ratelimit
+    command: /bin/ratelimit
+    build: .
     ports:
       - 8080:8080
       - 8081:8081
       - 6070:6070
     depends_on:
       - redis
-      - ratelimit-build
     networks:
       - ratelimit-network
     volumes:
-      - binary:/usr/local/bin/
       - ./examples:/data
     environment:
       - USE_STATSD=false
@@ -44,6 +33,3 @@ services:
 
 networks:
   ratelimit-network:
-
-volumes:
-  binary:


### PR DESCRIPTION
It looks like Dockerfile is not being used at all during the build and in the docker-compose command. This change updates docker-compose to use Dockerfile to build ratelimit binary.