### PR TITLE
Dockerfile does not build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /go/src/github.com/lyft/ratelimit
 
 COPY src src
 COPY script script
-COPY vendor vendor
+RUN mkdir vendor
 COPY glide.yaml glide.yaml
 COPY glide.lock glide.lock
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /go/src/github.com/lyft/ratelimit
 COPY src src
 COPY script script
 RUN mkdir vendor
+COPY proto proto
 COPY glide.yaml glide.yaml
 COPY glide.lock glide.lock
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,3 +16,4 @@ RUN CGO_ENABLED=0 GOOS=linux go build -o /usr/local/bin/ratelimit -ldflags="-w -
 FROM alpine:3.8 AS final
 RUN apk --no-cache add ca-certificates
 COPY --from=build /usr/local/bin/ratelimit /bin/ratelimit
+ENTRYPOINT /bin/ratelimit


### PR DESCRIPTION
Multiple errors in dockerfile does not allow building. 

Commit #dff525b removes COPY for vendor folder and replaces this with a mkdir to create folder.
Commit #34868f9 copies in proto folder needed for compilation. This was previously not copied in and caused the below error.
`src/service_cmd/runner/runner.go:10:2: cannot find package "github.com/lyft/ratelimit/proto/ratelimit" in any of:
	/go/src/github.com/lyft/ratelimit/vendor/github.com/lyft/ratelimit/proto/ratelimit (vendor tree)
	/usr/local/go/src/github.com/lyft/ratelimit/proto/ratelimit (from $GOROOT)
	/go/src/github.com/lyft/ratelimit/proto/ratelimit (from $GOPATH)
`