### PR TITLE
Fix build Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ COPY script script
 COPY vendor vendor
 COPY glide.yaml glide.yaml
 COPY glide.lock glide.lock
+COPY proto proto
 
 RUN script/install-glide
 RUN glide install


### PR DESCRIPTION
Fix problem:
```
src/service_cmd/runner/runner.go:10:2: cannot find package "github.com/lyft/ratelimit/proto/ratelimit" in any of:
        /usr/local/go/src/github.com/lyft/ratelimit/vendor/github.com/lyft/ratelimit/proto/ratelimit (vendor tree)
        /usr/local/go/src/vendor/github.com/lyft/ratelimit/proto/ratelimit
        /usr/local/go/src/github.com/lyft/ratelimit/proto/ratelimit (from $GOROOT)
        /go/src/github.com/lyft/ratelimit/proto/ratelimit (from $GOPATH)
The command '/bin/sh -c go build -o /usr/local/bin/ratelimit src/service_cmd/main.go' returned a non-zero code: 1
```