### PR TITLE
healthcheck: allow customizable healthcheck name

### DIFF
--- a/src/server/server_impl.go
+++ b/src/server/server_impl.go
@@ -15,9 +15,9 @@ import (
 	"net"
 
 	"github.com/gorilla/mux"
-	"github.com/kavu/go_reuseport"
+	reuseport "github.com/kavu/go_reuseport"
 	"github.com/lyft/goruntime/loader"
-	"github.com/lyft/gostats"
+	stats "github.com/lyft/gostats"
 	"github.com/lyft/ratelimit/src/settings"
 	logger "github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
@@ -142,7 +142,7 @@ func newServer(name string, opts ...settings.Option) *server {
 	ret.router = mux.NewRouter()
 
 	// setup healthcheck path
-	ret.health = NewHealthChecker(health.NewServer())
+	ret.health = NewHealthChecker(health.NewServer(), "ratelimit")
 	ret.router.Path("/healthcheck").Handler(ret.health)
 	healthpb.RegisterHealthServer(ret.grpcServer, ret.health.grpc)
 

--- a/test/server/health_test.go
+++ b/test/server/health_test.go
@@ -19,7 +19,7 @@ func TestHealthCheck(t *testing.T) {
 
 	recorder := httptest.NewRecorder()
 
-	hc := server.NewHealthChecker(health.NewServer())
+	hc := server.NewHealthChecker(health.NewServer(), "ratelimit")
 
 	r, _ := http.NewRequest("GET", "http://1.2.3.4/healthcheck", nil)
 	hc.ServeHTTP(recorder, r)
@@ -49,7 +49,7 @@ func TestGrpcHealthCheck(t *testing.T) {
 	defer signal.Reset(syscall.SIGTERM)
 
 	grpcHealthServer := health.NewServer()
-	hc := server.NewHealthChecker(grpcHealthServer)
+	hc := server.NewHealthChecker(grpcHealthServer, "ratelimit")
 	healthpb.RegisterHealthServer(grpc.NewServer(), grpcHealthServer)
 
 	req := &healthpb.HealthCheckRequest{


### PR DESCRIPTION
Description: this patch allows a consumer of the server package to customize the name of the healthchecker.

Signed-off-by: Jose Nino <jnino@lyft.com>