### PR TITLE
fix: support auth without tls

### DIFF
--- a/src/service_cmd/runner/runner.go
+++ b/src/service_cmd/runner/runner.go
@@ -39,8 +39,10 @@ func Run() {
 
 	}
 	var otherPool redis.Pool
-	if s.RedisAuth != "" || s.RedisTls {
+	if s.RedisAuth != "" && s.RedisTls {
 		otherPool = redis.NewAuthTLSPoolImpl(srv.Scope().Scope("redis_pool"), s.RedisAuth, s.RedisUrl, s.RedisPoolSize)
+	} else if s.RedisAuth != "" {
+		otherPool = redis.NewAuthPoolImpl(srv.Scope().Scope("redis_pool"), s.RedisAuth, s.RedisUrl, s.RedisPoolSize)
 	} else {
 		otherPool = redis.NewPoolImpl(srv.Scope().Scope("redis_pool"), s.RedisSocketType, s.RedisUrl, s.RedisPoolSize)
 	}

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -53,6 +53,7 @@ func testBasicConfigAuthTLS(grpcPort, perSecond string) func(*testing.T) {
 	os.Setenv("REDIS_PERSECOND_URL", "localhost:16382")
 	os.Setenv("REDIS_URL", "localhost:16381")
 	os.Setenv("REDIS_AUTH", "password123")
+	os.Setenv("REDIS_TLS", "true")
 	os.Setenv("REDIS_PERSECOND_AUTH", "password123")
 	return testBasicBaseConfig(grpcPort, perSecond)
 }


### PR DESCRIPTION
Redis's auth is not related with SSL, a non-ssl connection can have auth too.