### PR TITLE
Add local cache to store whether it is over the limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ You can specify the debug port with the `DEBUG_PORT` environment variable. It de
 
 # Local Cache
 
-Ratelimit optimally uses [freecache](https://github.com/coocood/freecache) as its local caching layer, which stores the over-the-limit cache keys, and avoid reading 
+Ratelimit optionally uses [freecache](https://github.com/coocood/freecache) as its local caching layer, which stores the over-the-limit cache keys, and thus avoids reading the 
 redis cache again for the already over-the-limit keys. The local cache size can be configured via `LocalCacheSizeInBytes` in the [settings](https://github.com/lyft/ratelimit/blob/master/src/settings/settings.go).
 If `LocalCacheSizeInBytes` is 0, local cache is disabled.
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 - [Request Fields](#request-fields)
 - [Statistics](#statistics)
 - [Debug Port](#debug-port)
+- [Local Cache](#local-cache)
 - [Redis](#redis)
   - [One Redis Instance](#one-redis-instance)
   - [Two Redis Instances](#two-redis-instances)
@@ -374,6 +375,7 @@ $ curl 0:6070/
 You can specify the debug port with the `DEBUG_PORT` environment variable. It defaults to `6070`.
 
 # Local Cache
+
 Ratelimit optimally uses [freecache](https://github.com/coocood/freecache) as its local caching layer, which stores the over-the-limit cache keys, and avoid reading 
 redis cache again for the already over-the-limit keys. The local cache size can be configured via `LocalCacheSizeInBytes` in the [settings](https://github.com/lyft/ratelimit/blob/master/src/settings/settings.go).
 If `LocalCacheSizeInBytes` is 0, local cache is disabled.

--- a/README.md
+++ b/README.md
@@ -373,6 +373,11 @@ $ curl 0:6070/
 
 You can specify the debug port with the `DEBUG_PORT` environment variable. It defaults to `6070`.
 
+# Local Cache
+Ratelimit optimally uses [freecache](https://github.com/coocood/freecache) as its local caching layer, which stores the over-the-limit cache keys, and avoid reading 
+redis cache again for the already over-the-limit keys. The local cache size can be configured via `LocalCacheSizeInBytes` in the [settings](https://github.com/lyft/ratelimit/blob/master/src/settings/settings.go).
+If `LocalCacheSizeInBytes` is 0, local cache is disabled.
+
 # Redis
 
 Ratelimit uses Redis as its caching layer. Ratelimit supports two operation modes:

--- a/glide.lock
+++ b/glide.lock
@@ -1,6 +1,10 @@
-hash: dbaf34c6a11259517cf882afa8a5ecf03eade91f1cac4c4e54edc30a3b4fdd3e
-updated: 2019-04-08T10:22:39.596389-07:00
+hash: 8cc8fb031b0204aa915eaa8947e364aa1ce4362a3a9eede8086ffa97ced02b4c
+updated: 2019-12-19T15:33:02.225239-08:00
 imports:
+- name: github.com/cespare/xxhash
+  version: d7df74196a9e781ede915320c11c378c1b2f3a1f
+- name: github.com/coocood/freecache
+  version: 3c79a0a23c1940ab4479332fb3e0127265650ce3
 - name: github.com/envoyproxy/go-control-plane
   version: 0ad6fa1cf0b9b6ca8f3617a7188a568e81f40b87
   subpackages:
@@ -13,7 +17,7 @@ imports:
 - name: github.com/fsnotify/fsnotify
   version: 629574ca2a5df945712d3079857300b5e4da0236
 - name: github.com/gogo/protobuf
-  version: ba06b47c162d49f2af050fb4c75bcbc86a159d5c
+  version: 5628607bb4c51c3157aacc3a50f0ab707582b805
   subpackages:
   - gogoproto
   - proto
@@ -22,7 +26,7 @@ imports:
   - sortkeys
   - types
 - name: github.com/golang/mock
-  version: 8a44ef6e8be577e050008c7886f24fc705d709fb
+  version: 41e7e9a91aa20115266b326233308d17079ea51c
   subpackages:
   - gomock
 - name: github.com/golang/protobuf
@@ -39,7 +43,7 @@ imports:
 - name: github.com/google/protobuf
   version: 6973c3a5041636c1d8dc5f7f6c8c1f3c15bc63d6
 - name: github.com/gorilla/mux
-  version: 9e1f5955c0d22b55d9e20d6faa28589f83b2faca
+  version: 49c01487a141b49f8ffe06277f3dca3ee80a55fa
 - name: github.com/kavu/go_reuseport
   version: 3d6c1e425f717ee59152524e73b904b67705eeb8
 - name: github.com/kelseyhightower/envconfig
@@ -57,7 +61,7 @@ imports:
   subpackages:
   - validate
 - name: github.com/mediocregopher/radix.v2
-  version: 94360be262532d465b7e4760c7a67195d3319a87
+  version: b67df6e626f993b64b3ca9f4b8630900e61002e3
   subpackages:
   - pool
   - redis
@@ -68,11 +72,11 @@ imports:
   subpackages:
   - assert
 - name: golang.org/x/crypto
-  version: 81e90905daefcd6fd217b62423c0908922eadb30
+  version: becbf705a91575484002d598f87d74f0002801e7
   subpackages:
   - ssh/terminal
 - name: golang.org/x/net
-  version: d0887baf81f4598189d4e12a37c6da86f0bba4d0
+  version: c0dbc17a35534bf2e581d7a942408dc936316da4
   subpackages:
   - context
   - http/httpguts
@@ -87,14 +91,14 @@ imports:
   - unix
   - windows
 - name: golang.org/x/text
-  version: b19bf474d317b857955b12035d2c5acb57ce8b01
+  version: cbf43d21aaebfdfeb81d91a5f444d13a3046e686
   subpackages:
   - secure/bidirule
   - transform
   - unicode/bidi
   - unicode/norm
 - name: google.golang.org/genproto
-  version: 221a8d4f74948678f06caaa13c9d41d22e069ae8
+  version: b31c10ee225f87dbb9f5f878ead9d64f34f5cbbb
   subpackages:
   - googleapis/rpc/status
 - name: google.golang.org/grpc
@@ -126,7 +130,7 @@ imports:
   - tap
   - transport
 - name: gopkg.in/yaml.v2
-  version: 5420a8b6744d3b0345ab293f6fcba19c978f1183
+  version: 1f64d6156d11335c3f22d9330b0ad14fc1e789ce
 testImports:
 - name: github.com/davecgh/go-spew
   version: 2df174808ee097f90d259e432cc04442cf60be21

--- a/glide.yaml
+++ b/glide.yaml
@@ -37,3 +37,5 @@ import:
   version: v3.7.1
 - package: github.com/golang/protobuf/proto
   version: v1.3.1
+- package: github.com/coocood/freecache
+  version: v1.1.0

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -3,7 +3,7 @@ package config
 import (
 	pb_struct "github.com/envoyproxy/go-control-plane/envoy/api/v2/ratelimit"
 	pb "github.com/envoyproxy/go-control-plane/envoy/service/ratelimit/v2"
-	"github.com/lyft/gostats"
+	stats "github.com/lyft/gostats"
 	"golang.org/x/net/context"
 )
 
@@ -21,9 +21,10 @@ func (e RateLimitConfigError) Error() string {
 
 // Stats for an individual rate limit config entry.
 type RateLimitStats struct {
-	TotalHits stats.Counter
-	OverLimit stats.Counter
-	NearLimit stats.Counter
+	TotalHits               stats.Counter
+	OverLimit               stats.Counter
+	NearLimit               stats.Counter
+	OverLimitWithLocalCache stats.Counter
 }
 
 // Wrapper for an individual rate limit config entry which includes the defined limit and stats.

--- a/src/config/config_impl.go
+++ b/src/config/config_impl.go
@@ -6,7 +6,7 @@ import (
 
 	pb_struct "github.com/envoyproxy/go-control-plane/envoy/api/v2/ratelimit"
 	pb "github.com/envoyproxy/go-control-plane/envoy/service/ratelimit/v2"
-	"github.com/lyft/gostats"
+	stats "github.com/lyft/gostats"
 	logger "github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 	"gopkg.in/yaml.v2"
@@ -61,6 +61,7 @@ func newRateLimitStats(statsScope stats.Scope, key string) RateLimitStats {
 	ret.TotalHits = statsScope.NewCounter(key + ".total_hits")
 	ret.OverLimit = statsScope.NewCounter(key + ".over_limit")
 	ret.NearLimit = statsScope.NewCounter(key + ".near_limit")
+	ret.OverLimitWithLocalCache = statsScope.NewCounter(key + ".over_limit_with_local_cache")
 	return ret
 }
 

--- a/src/redis/cache_impl.go
+++ b/src/redis/cache_impl.go
@@ -290,12 +290,7 @@ func (this *rateLimitCacheImpl) DoLimit(
 	return responseDescriptorStatuses
 }
 
-func NewRateLimitCacheImpl(pool Pool, perSecondPool Pool, timeSource TimeSource, jitterRand *rand.Rand, expirationJitterMaxSeconds int64, localCacheSize int) RateLimitCache {
-	var localCache *freecache.Cache
-	if localCacheSize != 0 {
-		localCache = freecache.NewCache(localCacheSize)
-	}
-
+func NewRateLimitCacheImpl(pool Pool, perSecondPool Pool, timeSource TimeSource, jitterRand *rand.Rand, expirationJitterMaxSeconds int64, localCache *freecache.Cache) RateLimitCache {
 	return &rateLimitCacheImpl{
 		pool:                       pool,
 		perSecondPool:              perSecondPool,

--- a/src/redis/cache_impl.go
+++ b/src/redis/cache_impl.go
@@ -117,15 +117,6 @@ func pipelineFetch(conn Connection) uint32 {
 	return ret
 }
 
-func (this *rateLimitCacheImpl) getExpirationSeconds(unit pb.RateLimitResponse_RateLimit_Unit) int64 {
-	expirationSeconds := unitToDivider(unit)
-	if this.expirationJitterMaxSeconds > 0 {
-		expirationSeconds += this.jitterRand.Int63n(this.expirationJitterMaxSeconds)
-	}
-
-	return expirationSeconds
-}
-
 func (this *rateLimitCacheImpl) DoLimit(
 	ctx context.Context,
 	request *pb.RateLimitRequest,

--- a/src/service_cmd/runner/runner.go
+++ b/src/service_cmd/runner/runner.go
@@ -51,7 +51,8 @@ func Run() {
 			perSecondPool,
 			redis.NewTimeSourceImpl(),
 			rand.New(redis.NewLockedSource(time.Now().Unix())),
-			s.ExpirationJitterMaxSeconds),
+			s.ExpirationJitterMaxSeconds,
+			s.LocalCacheSize),
 		config.NewRateLimitConfigLoaderImpl(),
 		srv.Scope().Scope("service"))
 

--- a/src/service_cmd/runner/runner.go
+++ b/src/service_cmd/runner/runner.go
@@ -1,11 +1,12 @@
 package runner
 
 import (
-	"github.com/coocood/freecache"
 	"io"
 	"math/rand"
 	"net/http"
 	"time"
+
+	"github.com/coocood/freecache"
 
 	pb "github.com/envoyproxy/go-control-plane/envoy/service/ratelimit/v2"
 	pb_legacy "github.com/lyft/ratelimit/proto/ratelimit"
@@ -47,8 +48,8 @@ func Run() {
 	}
 
 	var localCache *freecache.Cache
-	if s.LocalCacheSize != 0 {
-		localCache = freecache.NewCache(s.LocalCacheSize)
+	if s.LocalCacheSizeInBytes != 0 {
+		localCache = freecache.NewCache(s.LocalCacheSizeInBytes)
 	}
 	service := ratelimit.NewService(
 		srv.Runtime(),

--- a/src/settings/settings.go
+++ b/src/settings/settings.go
@@ -31,7 +31,7 @@ type Settings struct {
 	RedisPerSecondAuth         string `envconfig:"REDIS_PERSECOND_AUTH" default:""`
 	RedisPerSecondTls          bool   `envconfig:"REDIS_PERSECOND_TLS" default:"false"`
 	ExpirationJitterMaxSeconds int64  `envconfig:"EXPIRATION_JITTER_MAX_SECONDS" default:"300"`
-	LocalCacheSize             int    `envconfig:"LOCAL_CACHE_SIZE" default:"0"`
+	LocalCacheSizeInBytes      int    `envconfig:"LOCAL_CACHE_SIZE_IN_BYTES" default:"0"`
 }
 
 type Option func(*Settings)

--- a/src/settings/settings.go
+++ b/src/settings/settings.go
@@ -31,6 +31,7 @@ type Settings struct {
 	RedisPerSecondAuth         string `envconfig:"REDIS_PERSECOND_AUTH" default:""`
 	RedisPerSecondTls          bool   `envconfig:"REDIS_PERSECOND_TLS" default:"false"`
 	ExpirationJitterMaxSeconds int64  `envconfig:"EXPIRATION_JITTER_MAX_SECONDS" default:"300"`
+	LocalCacheSize             int    `envconfig:"LOCAL_CACHE_SIZE" default:"0"`
 }
 
 type Option func(*Settings)

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -41,14 +41,12 @@ func newDescriptorStatusLegacy(
 	}
 }
 
-
 func TestBasicConfig(t *testing.T) {
 	t.Run("WithoutPerSecondRedis", testBasicConfig("8083", "false", "0"))
 	t.Run("WithPerSecondRedis", testBasicConfig("8085", "true", "0"))
 	t.Run("WithoutPerSecondRedisWithLocalCache", testBasicConfig("8083", "false", "1000"))
 	t.Run("WithPerSecondRedisWithLocalCache", testBasicConfig("8085", "true", "1000"))
 }
-
 
 func TestBasicTLSConfig(t *testing.T) {
 	t.Run("WithoutPerSecondRedisTLS", testBasicConfigAuthTLS("8087", "false", "0"))
@@ -206,7 +204,6 @@ func testBasicConfigLegacy(local_cache_size string) func(*testing.T) {
 		os.Setenv("LOCAL_CACHE_SIZE", local_cache_size)
 		local_cache_size_val, _ := strconv.Atoi(local_cache_size)
 		enable_local_cache := local_cache_size_val > 0
-
 
 		go func() {
 			runner.Run()

--- a/test/integration/runtime/current/ratelimit/config/another.yaml
+++ b/test/integration/runtime/current/ratelimit/config/another.yaml
@@ -9,3 +9,13 @@ descriptors:
     rate_limit:
       unit: hour
       requests_per_unit: 10
+
+  - key: key2_local
+    rate_limit:
+      unit: minute
+      requests_per_unit: 20
+
+  - key: key3_local
+    rate_limit:
+      unit: hour
+      requests_per_unit: 10

--- a/test/integration/runtime/current/ratelimit/config/another_legacy.yaml
+++ b/test/integration/runtime/current/ratelimit/config/another_legacy.yaml
@@ -9,3 +9,13 @@ descriptors:
     rate_limit:
       unit: hour
       requests_per_unit: 10
+
+  - key: key2_local
+    rate_limit:
+      unit: minute
+      requests_per_unit: 20
+
+  - key: key3_local
+    rate_limit:
+      unit: hour
+      requests_per_unit: 10

--- a/test/integration/runtime/current/ratelimit/config/basic.yaml
+++ b/test/integration/runtime/current/ratelimit/config/basic.yaml
@@ -4,3 +4,8 @@ descriptors:
     rate_limit:
       unit: second
       requests_per_unit: 50
+
+  - key: key1_local
+    rate_limit:
+      unit: second
+      requests_per_unit: 50

--- a/test/integration/runtime/current/ratelimit/config/basic_legacy.yaml
+++ b/test/integration/runtime/current/ratelimit/config/basic_legacy.yaml
@@ -4,3 +4,8 @@ descriptors:
     rate_limit:
       unit: second
       requests_per_unit: 50
+
+  - key: key1_local
+    rate_limit:
+      unit: second
+      requests_per_unit: 50

--- a/test/redis/cache_impl_test.go
+++ b/test/redis/cache_impl_test.go
@@ -1,6 +1,7 @@
 package redis_test
 
 import (
+	"github.com/coocood/freecache"
 	"testing"
 
 	pb "github.com/envoyproxy/go-control-plane/envoy/service/ratelimit/v2"
@@ -36,9 +37,9 @@ func testRedis(usePerSecondRedis bool) func(*testing.T) {
 		response := mock_redis.NewMockResponse(controller)
 		var cache redis.RateLimitCache
 		if usePerSecondRedis {
-			cache = redis.NewRateLimitCacheImpl(pool, perSecondPool, timeSource, rand.New(rand.NewSource(1)), 0, 0)
+			cache = redis.NewRateLimitCacheImpl(pool, perSecondPool, timeSource, rand.New(rand.NewSource(1)), 0, nil)
 		} else {
-			cache = redis.NewRateLimitCacheImpl(pool, nil, timeSource, rand.New(rand.NewSource(1)), 0, 0)
+			cache = redis.NewRateLimitCacheImpl(pool, nil, timeSource, rand.New(rand.NewSource(1)), 0, nil)
 		}
 		statsStore := stats.NewStore(stats.NewNullSink(), false)
 
@@ -160,7 +161,7 @@ func TestOverLimitWithLocalCache(t *testing.T) {
 	timeSource := mock_redis.NewMockTimeSource(controller)
 	connection := mock_redis.NewMockConnection(controller)
 	response := mock_redis.NewMockResponse(controller)
-	cache := redis.NewRateLimitCacheImpl(pool, nil, timeSource, rand.New(rand.NewSource(1)), 0, 1000)
+	cache := redis.NewRateLimitCacheImpl(pool, nil, timeSource, rand.New(rand.NewSource(1)), 0, freecache.NewCache(100))
 	statsStore := stats.NewStore(stats.NewNullSink(), false)
 
 	// Test Near Limit Stats. Under Near Limit Ratio
@@ -231,6 +232,11 @@ func TestOverLimitWithLocalCache(t *testing.T) {
 	// Test Over limit stats with local cache
 	pool.EXPECT().Get().Return(connection)
 	timeSource.EXPECT().UnixNow().Return(int64(1000000))
+	connection.EXPECT().PipeAppend("INCRBY", "domain_key4_value4_997200", uint32(1)).Times(0)
+	connection.EXPECT().PipeAppend(
+		"EXPIRE", "domain_key4_value4_997200", int64(3600)).Times(0)
+	connection.EXPECT().PipeResponse().Times(0)
+	response.EXPECT().Int().Times(0)
 	pool.EXPECT().Put(connection)
 	assert.Equal(
 		[]*pb.RateLimitResponse_DescriptorStatus{
@@ -251,7 +257,7 @@ func TestNearLimit(t *testing.T) {
 	timeSource := mock_redis.NewMockTimeSource(controller)
 	connection := mock_redis.NewMockConnection(controller)
 	response := mock_redis.NewMockResponse(controller)
-	cache := redis.NewRateLimitCacheImpl(pool, nil, timeSource, rand.New(rand.NewSource(1)), 0, 0)
+	cache := redis.NewRateLimitCacheImpl(pool, nil, timeSource, rand.New(rand.NewSource(1)), 0, nil)
 	statsStore := stats.NewStore(stats.NewNullSink(), false)
 
 	// Test Near Limit Stats. Under Near Limit Ratio
@@ -449,7 +455,7 @@ func TestRedisWithJitter(t *testing.T) {
 	connection := mock_redis.NewMockConnection(controller)
 	response := mock_redis.NewMockResponse(controller)
 	jitterSource := mock_redis.NewMockJitterRandSource(controller)
-	cache := redis.NewRateLimitCacheImpl(pool, nil, timeSource, rand.New(jitterSource), 3600, 0)
+	cache := redis.NewRateLimitCacheImpl(pool, nil, timeSource, rand.New(jitterSource), 3600, nil)
 	statsStore := stats.NewStore(stats.NewNullSink(), false)
 
 	pool.EXPECT().Get().Return(connection)

--- a/test/redis/cache_impl_test.go
+++ b/test/redis/cache_impl_test.go
@@ -4,15 +4,16 @@ import (
 	"testing"
 
 	pb "github.com/envoyproxy/go-control-plane/envoy/service/ratelimit/v2"
-	"github.com/lyft/gostats"
+	stats "github.com/lyft/gostats"
 	"github.com/lyft/ratelimit/src/config"
 	"github.com/lyft/ratelimit/src/redis"
 
+	"math/rand"
+
 	"github.com/golang/mock/gomock"
 	"github.com/lyft/ratelimit/test/common"
-	"github.com/lyft/ratelimit/test/mocks/redis"
+	mock_redis "github.com/lyft/ratelimit/test/mocks/redis"
 	"github.com/stretchr/testify/assert"
-	"math/rand"
 )
 
 func TestRedis(t *testing.T) {
@@ -35,9 +36,9 @@ func testRedis(usePerSecondRedis bool) func(*testing.T) {
 		response := mock_redis.NewMockResponse(controller)
 		var cache redis.RateLimitCache
 		if usePerSecondRedis {
-			cache = redis.NewRateLimitCacheImpl(pool, perSecondPool, timeSource, rand.New(rand.NewSource(1)), 0)
+			cache = redis.NewRateLimitCacheImpl(pool, perSecondPool, timeSource, rand.New(rand.NewSource(1)), 0, 0)
 		} else {
-			cache = redis.NewRateLimitCacheImpl(pool, nil, timeSource, rand.New(rand.NewSource(1)), 0)
+			cache = redis.NewRateLimitCacheImpl(pool, nil, timeSource, rand.New(rand.NewSource(1)), 0, 0)
 		}
 		statsStore := stats.NewStore(stats.NewNullSink(), false)
 
@@ -150,6 +151,97 @@ func testRedis(usePerSecondRedis bool) func(*testing.T) {
 	}
 }
 
+func TestOverLimitWithLocalCache(t *testing.T) {
+	assert := assert.New(t)
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	pool := mock_redis.NewMockPool(controller)
+	timeSource := mock_redis.NewMockTimeSource(controller)
+	connection := mock_redis.NewMockConnection(controller)
+	response := mock_redis.NewMockResponse(controller)
+	cache := redis.NewRateLimitCacheImpl(pool, nil, timeSource, rand.New(rand.NewSource(1)), 0, 1000)
+	statsStore := stats.NewStore(stats.NewNullSink(), false)
+
+	// Test Near Limit Stats. Under Near Limit Ratio
+	pool.EXPECT().Get().Return(connection)
+	timeSource.EXPECT().UnixNow().Return(int64(1000000))
+	connection.EXPECT().PipeAppend("INCRBY", "domain_key4_value4_997200", uint32(1))
+	connection.EXPECT().PipeAppend(
+		"EXPIRE", "domain_key4_value4_997200", int64(3600))
+	connection.EXPECT().PipeResponse().Return(response)
+	response.EXPECT().Int().Return(int64(11))
+	connection.EXPECT().PipeResponse()
+	pool.EXPECT().Put(connection)
+
+	request := common.NewRateLimitRequest("domain", [][][2]string{{{"key4", "value4"}}}, 1)
+
+	limits := []*config.RateLimit{
+		config.NewRateLimit(15, pb.RateLimitResponse_RateLimit_HOUR, "key4_value4", statsStore)}
+
+	assert.Equal(
+		[]*pb.RateLimitResponse_DescriptorStatus{
+			{Code: pb.RateLimitResponse_OK, CurrentLimit: limits[0].Limit, LimitRemaining: 4}},
+		cache.DoLimit(nil, request, limits))
+	assert.Equal(uint64(1), limits[0].Stats.TotalHits.Value())
+	assert.Equal(uint64(0), limits[0].Stats.OverLimit.Value())
+	assert.Equal(uint64(0), limits[0].Stats.OverLimitWithLocalCache.Value())
+	assert.Equal(uint64(0), limits[0].Stats.NearLimit.Value())
+
+	// Test Near Limit Stats. At Near Limit Ratio, still OK
+	pool.EXPECT().Get().Return(connection)
+	timeSource.EXPECT().UnixNow().Return(int64(1000000))
+	connection.EXPECT().PipeAppend("INCRBY", "domain_key4_value4_997200", uint32(1))
+	connection.EXPECT().PipeAppend(
+		"EXPIRE", "domain_key4_value4_997200", int64(3600))
+	connection.EXPECT().PipeResponse().Return(response)
+	response.EXPECT().Int().Return(int64(13))
+	connection.EXPECT().PipeResponse()
+	pool.EXPECT().Put(connection)
+
+	assert.Equal(
+		[]*pb.RateLimitResponse_DescriptorStatus{
+			{Code: pb.RateLimitResponse_OK, CurrentLimit: limits[0].Limit, LimitRemaining: 2}},
+		cache.DoLimit(nil, request, limits))
+	assert.Equal(uint64(2), limits[0].Stats.TotalHits.Value())
+	assert.Equal(uint64(0), limits[0].Stats.OverLimit.Value())
+	assert.Equal(uint64(0), limits[0].Stats.OverLimitWithLocalCache.Value())
+	assert.Equal(uint64(1), limits[0].Stats.NearLimit.Value())
+
+	// Test Over limit stats
+	pool.EXPECT().Get().Return(connection)
+	timeSource.EXPECT().UnixNow().Return(int64(1000000))
+	connection.EXPECT().PipeAppend("INCRBY", "domain_key4_value4_997200", uint32(1))
+	connection.EXPECT().PipeAppend(
+		"EXPIRE", "domain_key4_value4_997200", int64(3600))
+	connection.EXPECT().PipeResponse().Return(response)
+	response.EXPECT().Int().Return(int64(16))
+	connection.EXPECT().PipeResponse()
+	pool.EXPECT().Put(connection)
+
+	assert.Equal(
+		[]*pb.RateLimitResponse_DescriptorStatus{
+			{Code: pb.RateLimitResponse_OVER_LIMIT, CurrentLimit: limits[0].Limit, LimitRemaining: 0}},
+		cache.DoLimit(nil, request, limits))
+	assert.Equal(uint64(3), limits[0].Stats.TotalHits.Value())
+	assert.Equal(uint64(1), limits[0].Stats.OverLimit.Value())
+	assert.Equal(uint64(0), limits[0].Stats.OverLimitWithLocalCache.Value())
+	assert.Equal(uint64(1), limits[0].Stats.NearLimit.Value())
+
+	// Test Over limit stats with local cache
+	pool.EXPECT().Get().Return(connection)
+	timeSource.EXPECT().UnixNow().Return(int64(1000000))
+	pool.EXPECT().Put(connection)
+	assert.Equal(
+		[]*pb.RateLimitResponse_DescriptorStatus{
+			{Code: pb.RateLimitResponse_OVER_LIMIT, CurrentLimit: limits[0].Limit, LimitRemaining: 0}},
+		cache.DoLimit(nil, request, limits))
+	assert.Equal(uint64(4), limits[0].Stats.TotalHits.Value())
+	assert.Equal(uint64(2), limits[0].Stats.OverLimit.Value())
+	assert.Equal(uint64(1), limits[0].Stats.OverLimitWithLocalCache.Value())
+	assert.Equal(uint64(1), limits[0].Stats.NearLimit.Value())
+}
+
 func TestNearLimit(t *testing.T) {
 	assert := assert.New(t)
 	controller := gomock.NewController(t)
@@ -159,7 +251,7 @@ func TestNearLimit(t *testing.T) {
 	timeSource := mock_redis.NewMockTimeSource(controller)
 	connection := mock_redis.NewMockConnection(controller)
 	response := mock_redis.NewMockResponse(controller)
-	cache := redis.NewRateLimitCacheImpl(pool, nil, timeSource, rand.New(rand.NewSource(1)), 0)
+	cache := redis.NewRateLimitCacheImpl(pool, nil, timeSource, rand.New(rand.NewSource(1)), 0, 0)
 	statsStore := stats.NewStore(stats.NewNullSink(), false)
 
 	// Test Near Limit Stats. Under Near Limit Ratio
@@ -357,7 +449,7 @@ func TestRedisWithJitter(t *testing.T) {
 	connection := mock_redis.NewMockConnection(controller)
 	response := mock_redis.NewMockResponse(controller)
 	jitterSource := mock_redis.NewMockJitterRandSource(controller)
-	cache := redis.NewRateLimitCacheImpl(pool, nil, timeSource, rand.New(jitterSource), 3600)
+	cache := redis.NewRateLimitCacheImpl(pool, nil, timeSource, rand.New(jitterSource), 3600, 0)
 	statsStore := stats.NewStore(stats.NewNullSink(), false)
 
 	pool.EXPECT().Get().Return(connection)


### PR DESCRIPTION
According to https://docs.google.com/document/d/1rucr2O-zfxiYf3fAZYsap-CCtVnwqKbj6nD-ebCZda8/edit?usp=sharing, add local cache to store whether it is over the the limit, and avoid reading redis cache for the already over-the-limit cache_keys.